### PR TITLE
feat : Add Logout with CustomLogoutSuccessHandler

### DIFF
--- a/src/main/java/com/sparta/springcafeservice/entity/Order.java
+++ b/src/main/java/com/sparta/springcafeservice/entity/Order.java
@@ -9,6 +9,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 
 @Entity
 @Getter

--- a/src/main/java/com/sparta/springcafeservice/entity/Store.java
+++ b/src/main/java/com/sparta/springcafeservice/entity/Store.java
@@ -54,9 +54,9 @@ public class Store extends TimeStamped{
         this.information = requestDto.getInformation();
     }
 
-    public void addReviewList(Review comment) {
+    public void addReviewList(Review review) {
         // Comment 객체를 Store와 연결
-        comment.setStore(this); // Comment 엔티티에 있는 setStore 메서드를 활용하여 연결
+        review.setStore(this); // Comment 엔티티에 있는 setStore 메서드를 활용하여 연결
 
         // Comment 객체를 Store의 commentList에 추가
     }

--- a/src/main/java/com/sparta/springcafeservice/security/CustomLogoutSuccessHandler.java
+++ b/src/main/java/com/sparta/springcafeservice/security/CustomLogoutSuccessHandler.java
@@ -1,0 +1,34 @@
+package com.sparta.springcafeservice.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class CustomLogoutSuccessHandler implements LogoutSuccessHandler {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
+        // 로그아웃 성공 시 JSON 응답을 반환
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("msg", "로그아웃 성공");
+        responseBody.put("statusCode", HttpStatus.OK.value());
+
+        response.setStatus(HttpStatus.OK.value());
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType("application/json;charset=UTF-8");
+        objectMapper.writeValue(response.getWriter(), responseBody);
+    }
+}

--- a/src/main/java/com/sparta/springcafeservice/service/OrderService.java
+++ b/src/main/java/com/sparta/springcafeservice/service/OrderService.java
@@ -79,7 +79,6 @@ public class OrderService {
         // user가 order에서 가져온 userId값과 다를 때(동일 사장) 예외처리
         if (!user.getId().equals(order.getStore().getUser().getId())) {
             throw new IllegalArgumentException("주문상태를 변경할 권한이 없습니다.");
-//            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("주문 취소 권한이 없습니다.");
         }
         order.update(requestDto);
         //수정 성공
@@ -93,7 +92,6 @@ public class OrderService {
         // user가 order에서 가져온 userId값과 다를 때(동일 사장) 예외처리
         if (!user.getId().equals(order.getStore().getUser().getId())) {
             throw new IllegalArgumentException("주문을 취소할 권한이 없습니다.");
-//            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("주문 취소 권한이 없습니다.");
         }
 
         return ResponseEntity.ok("주문을 취소하였습니다.");


### PR DESCRIPTION
* 로그아웃 부분 구현입니다. 저장되는 쿠키의 이름을 정확히 지정하여 올바른 쿠키를 삭제하도록 수정되었습니다.
* CustomLogoutSuccessHandler를 통해서 msg와 httpStatus Code를 반환합니다. 
* 추후 프론트 엔드와 연결하여 인덱스로 리다이렉션 시,
  - WebSecurityConfig에서 http.logout() 부분에 현재 주석처리해둔 부분을 "/" 리다이렉션 코드를 풀면 프론트엔드로 정상 작동할것입니다.

* POSTMAN TEST 완료
![스크린샷 2023-09-18 오후 8 46 37](https://github.com/yzpocket/spring-cafeservice/assets/67217259/659b955d-f161-4baf-9a71-a856c3f6f283)


- 로그인 부분도 통일성을 위해서 핸들러를 통하도록 작업 할 수 있으나,
- 로그인은 Spring Security 자체에서 커스터마이즈 폼 로그인을 사용하면,
- 로그인 성공 시  `msg`와 `statusCode`를 디폴트로 반환하기에 궂이 작업하지 않았습니다.